### PR TITLE
Update IndexListener to prevent infinite loop

### DIFF
--- a/EventListener/IndexListener.php
+++ b/EventListener/IndexListener.php
@@ -91,11 +91,21 @@ class IndexListener implements EventSubscriber
 
     public function preRemove(LifecycleEventArgs $args)
     {
+        static $visited = [];
+
         $em = $args->getObjectManager();
         $entity = $args->getObject();
         if ($entity instanceof Index) {
             return;
         }
+
+        // Prevent infinite recursion
+        $oid = spl_object_hash($entity);
+        if (isset($visited[$oid])) {
+            return;
+        }
+        $visited[$oid] = true;
+
         $entityName = \get_class($entity);
         if (!$this->indexManager->hasEntityIndexes($entityName)) {
             return;


### PR DESCRIPTION
We have a use case where, because of orphan removal, we have an infinite
loop because of the IndexListener. I'm not sure if we can easily share a
minimal POC that proves the bug, but I _can_ tell you that this fixes
it. Either way it's a form of defensive programming to prevent it in
general.

I was looking to use `\Doctrine\ORM\UnitOfWork::getEntityState()` first,
and skip the entity when the state is already set to
`\Doctrine\ORM\UnitOfWork::STATE_REMOVED`, but the problem is that the
entity doesn't have that state yet, because it's the *pre*Remove event.